### PR TITLE
Request Administrator's Credentials adhoc

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -96,6 +96,7 @@ $use_resetpassword = true;
 $resetpassword_reset_default = true;
 $use_unlockaccount = true;
 $use_lockaccount = true;
+$always_authenticate_admin = false;
 
 # Language
 $lang ="en";

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -68,6 +68,7 @@ $smarty->assign('use_resetpassword',$use_resetpassword);
 $smarty->assign('resetpassword_reset_default',$resetpassword_reset_default);
 $smarty->assign('use_unlockaccount',$use_unlockaccount);
 $smarty->assign('use_lockaccount',$use_lockaccount);
+$smarty->assign('always_authenticate_admin',$always_authenticate_admin);
 
 # Assign messages
 $smarty->assign('lang',$lang);

--- a/htdocs/lockaccount.php
+++ b/htdocs/lockaccount.php
@@ -28,9 +28,7 @@ if ($result === "") {
     $result = $ldap_connection[1];
 
     if ($ldap) {
-        date_default_timezone_set("UTC");
-        $lock_time = date("YmdHis")."Z";
-        $modification = ldap_mod_replace($ldap, $dn, array("pwdAccountLockedTime" => array($lock_time)));
+        $modification = ldap_mod_replace($ldap, $dn, array("pwdAccountLockedTime" => array("000001010000Z")));
         $errno = ldap_errno($ldap);
         if ( $errno ) {
             $result = "ldaperror";

--- a/htdocs/lockaccount.php
+++ b/htdocs/lockaccount.php
@@ -6,6 +6,8 @@
 $result = "";
 $dn = "";
 $password = "";
+$ldap_binddn = "";
+$ldap_bindpw = "";
 
 if (isset($_POST["dn"]) and $_POST["dn"]) {
     $dn = $_POST["dn"];
@@ -13,10 +15,11 @@ if (isset($_POST["dn"]) and $_POST["dn"]) {
     $result = "dnrequired";
 }
 
-if ($result === "") {
+require_once("../conf/config.inc.php");
+require_once("../lib/ldap.inc.php");
+require_once("../lib/authenticate_admin.inc.php");
 
-    require_once("../conf/config.inc.php");
-    require_once("../lib/ldap.inc.php");
+if ($result === "") {
 
     # Connect to LDAP
     $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw);
@@ -25,7 +28,9 @@ if ($result === "") {
     $result = $ldap_connection[1];
 
     if ($ldap) {
-        $modification = ldap_mod_replace($ldap, $dn, array("pwdAccountLockedTime" => array("000001010000Z")));
+        date_default_timezone_set("UTC");
+        $lock_time = date("YmdHis")."Z";
+        $modification = ldap_mod_replace($ldap, $dn, array("pwdAccountLockedTime" => array($lock_time)));
         $errno = ldap_errno($ldap);
         if ( $errno ) {
             $result = "ldaperror";

--- a/htdocs/resetpassword.php
+++ b/htdocs/resetpassword.php
@@ -25,11 +25,12 @@ if (isset($_POST["pwdreset"]) and $_POST["pwdreset"]) {
     $pwdreset = $_POST["pwdreset"];
 }
 
-if ($result === "") {
+require_once("../conf/config.inc.php");
+require_once("../lib/ldap.inc.php");
+require_once("../lib/posthook.inc.php");
+require_once("../lib/authenticate_admin.inc.php");
 
-    require_once("../conf/config.inc.php");
-    require_once("../lib/ldap.inc.php");
-    require_once("../lib/posthook.inc.php");
+if ($result === "") {
 
     # Connect to LDAP
     $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw);

--- a/htdocs/unlockaccount.php
+++ b/htdocs/unlockaccount.php
@@ -13,10 +13,11 @@ if (isset($_POST["dn"]) and $_POST["dn"]) {
     $result = "dnrequired";
 }
 
-if ($result === "") {
+require_once("../conf/config.inc.php");
+require_once("../lib/ldap.inc.php");
+require_once("../lib/authenticate_admin.inc.php");
 
-    require_once("../conf/config.inc.php");
-    require_once("../lib/ldap.inc.php");
+if ($result === "") {
 
     # Connect to LDAP
     $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw);

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -78,5 +78,9 @@ $messages['true'] = "Yes";
 $messages['unlockaccount'] = "Unlock account";
 $messages['unlockdate'] = "Automatic unlock date:";
 $messages['welcome'] = "Welcome to LDAP Tool Box service desk";
+$messages['label_admin_credentials'] = "Administrator's Credentials";
+$messages['admin_username'] = "Administrator's username";
+$messages['admin_password'] = "Administrator's password";
+$messages['admincredentialsrequired'] = "Administrator's Credentials required";
 
 ?>

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -78,5 +78,9 @@ $messages['true'] = "Oui";
 $messages['unlockaccount'] = "Débloquer le compte";
 $messages['unlockdate'] = "Date de déblocage automatique :";
 $messages['welcome'] = "Bienvenue sur le guichet de service LDAP Tool Box";
+$messages['label_admin_credentials'] = "Informations d'identification de l'administrateur";
+$messages['admin_username'] = "Nom d'utilisateur de l'administrateur";
+$messages['admin_password'] = "Mot de passe administrateur";
+$messages['admincredentialsrequired'] = "Informations d'identification de l'administrateur requises";
 
 ?>

--- a/lib/authenticate_admin.inc.php
+++ b/lib/authenticate_admin.inc.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * Reset password in LDAP directory
+ */
+
+if($result === "" and $always_authenticate_admin) {
+    if(isset($_POST["admin_username"]) and $_POST["admin_username"] and isset($_POST["admin_password"]) and $_POST["admin_password"]) {
+        $ldap_binddn = $ldap_login_attribute ."=" . $_POST["admin_username"] ."," . $ldap_user_base;
+        $ldap_bindpw = $_POST["admin_password"];
+    } else {
+        $result = "admincredentialsrequired";
+    }
+}
+
+?>

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -179,6 +179,19 @@
                              </div>
                          </div>
                      </div>
+                     {if $always_authenticate_admin}
+                         <div class="form-group">
+                             <div class="input-group"><p>{$msg_label_admin_credentials}</p></div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-user-circle"></i></span>
+                                 <input type="text" name="admin_username" id="admin_username" class="form-control" placeholder="{$msg_admin_username}" />
+                             </div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-lock"></i></span>
+                                 <input type="password" name="admin_password" id="admin_password" class="form-control" placeholder="{$msg_admin_password}" />
+                             </div>
+                         </div>
+                     {/if}
                      <div class="form-group">
                          <button type="submit" class="btn btn-success">
                              <i class="fa fa-fw fa-check-square-o"></i> {$msg_submit}
@@ -208,6 +221,19 @@
                      <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_accountnotunlocked}</div>
                      {/if}
                      <input type="hidden" name="dn" value="{$dn}" />
+                     {if $always_authenticate_admin}
+                         <div class="form-group">
+                             <div class="input-group"><p>{$msg_label_admin_credentials}</p></div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-user-circle"></i></span>
+                                 <input type="text" name="admin_username" id="admin_username" class="form-control" placeholder="{$msg_admin_username}" />
+                             </div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-lock"></i></span>
+                                 <input type="password" name="admin_password" id="admin_password" class="form-control" placeholder="{$msg_admin_password}" />
+                             </div>
+                         </div>
+                     {/if}
                      <div class="form-group">
                          <button type="submit" class="btn btn-success">
                              <i class="fa fa-fw fa-unlock"></i> {$msg_unlockaccount}
@@ -235,6 +261,19 @@
                      <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_accountnotlocked}</div>
                      {/if}
                      <input type="hidden" name="dn" value="{$dn}" />
+                     {if $always_authenticate_admin}
+                         <div class="form-group">
+                             <div class="input-group"><p>{$msg_label_admin_credentials}</p></div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-user-circle"></i></span>
+                                 <input type="text" name="admin_username" id="admin_username" class="form-control" placeholder="{$msg_admin_username}" />
+                             </div>
+                             <div class="input-group">
+                                 <span class="input-group-addon"><i class="fa fa-fw fa-lock"></i></span>
+                                 <input type="password" name="admin_password" id="admin_password" class="form-control" placeholder="{$msg_admin_password}" />
+                             </div>
+                         </div>
+                     {/if}
                      <div class="form-group">
                          <button type="submit" class="btn btn-success">
                              <i class="fa fa-fw fa-lock"></i> {$msg_lockaccount}


### PR DESCRIPTION
Setting bind user in configuration is not safe in some deployments,
as this user should have permissions to modify the following attributes
in LDAP:
* userPassword
* pwdReset
* pwdAccountLockedTime

For that reason, the `always_authenticate_admin` variable has been introduced
in `config.inc.php`. When set to true, input fields for administrator's username
and password appear in `Reset Password` and `Lock/Unlock Account` forms.
When user submits one of this form, then `ldap_bidndn` and `ldap_bindpw` are
taken from the respective `POST` variables, overwriting any value they have
in `config.inc.php` or `config.inc.local.php` files.
The default value of `always_authenticate_admin` is false, providing the
old functionality.