### PR TITLE
Timestamp value displayer

### DIFF
--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -15,9 +15,10 @@ Available types:
 * ``mailto``: mailto link
 * ``tel``: tel link
 * ``boolean``: true or false
-* ``date``: full date
+* ``date``: LDAP date converted to full date
 * ``list``: value from a list
 * ``bytes``: bytes converted in KB/MB/GB/TB
+* ``timestamp``: timestamp converted to full date
 
 .. tip:: See LDAP Tool Box White Pages documentation to get more information.
 

--- a/templates/value_displayer.tpl
+++ b/templates/value_displayer.tpl
@@ -26,3 +26,7 @@
 {if $type eq 'bytes'}
     {convert_bytes($value)|truncate:{$truncate_value_after}}<br />
 {/if}
+
+{if $type eq 'timestamp'}
+    {$value|date_format:{$date_specifiers}|truncate:{$truncate_value_after}}<br />
+{/if}


### PR DESCRIPTION
Allows to display a timestamp value as a date (for example to display value of shadowExpire attribute).