### PR TITLE
Authentication Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ templates_c/*
 cache/*
 docs/_build
 .vscode/*
+conf/config.inc.local.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 templates_c/*
 cache/*
 docs/_build
+.vscode/*

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -35,6 +35,7 @@ $ldap_size_limit = 100;
 #$ldap_default_ppolicy = "cn=default,ou=ppolicy,dc=example,dc=com";
 
 # Site Authentication Configuration. These are pre-filled with examples, please modify to suit your needs.
+$ldap_authentication = false;// Specify whether you'd like to secure the Service Desk site with LDAP authentication.
 $ldap_allowed_admin_users = array("Administrator");// UID's or SamAccountName(s) of users who are allowed to login and edit all accounts.
 $ldap_allowed_admin_ous = array("OU=Managers,DC=example,DC=com");// Organizational Unit(s) of users who are allowed to login and edit all accounts.
 $ldap_allowed_admin_groups = array("CN=Administrators,OU=Groups,DC=example,DC=com");// Security Group(s) of users who are allowed to login and edit all accounts.

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -34,6 +34,12 @@ $ldap_user_filter = "(objectClass=inetOrgPerson)";
 $ldap_size_limit = 100;
 #$ldap_default_ppolicy = "cn=default,ou=ppolicy,dc=example,dc=com";
 
+# Site Authentication Configuration. These are pre-filled with examples, please modify to suit your needs.
+$ldap_allowed_admin_users = array("Administrator");// UID's or SamAccountName(s) of users who are allowed to login and edit all accounts.
+$ldap_allowed_admin_ous = array("OU=Managers,DC=example,DC=com");// Organizational Unit(s) of users who are allowed to login and edit all accounts.
+$ldap_allowed_admin_groups = array("CN=Administrators,OU=Groups,DC=example,DC=com");// Security Group(s) of users who are allowed to login and edit all accounts.
+$ldap_disallowed_ous = array("OU=Guests,DC=example,DC=com");// Organizational Units of users who are NOT allowed to log in at all.
+
 # How display attributes
 $attributes_map = array(
     'authtimestamp' => array( 'attribute' => 'authtimestamp', 'faclass' => 'lock', 'type' => 'date' ),

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -21,7 +21,7 @@ if (isset($_GET["dn"]) and $_GET["dn"]) {
 } elseif (isset($_SESSION["entry_dn"])) {
     $dn = $_SESSION["entry_dn"];
 } else {
-    $result = "dnrequired";
+    // $result = "dnrequired";// Deprecating this error in favor of displaying welcome screen instead
 }
 
 if (isset($_GET["checkpasswordresult"]) and $_GET["checkpasswordresult"]) {

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -18,6 +18,8 @@ if (isset($_GET["dn"]) and $_GET["dn"]) {
     $dn = $_GET["dn"];
 } elseif (isset($entry_dn)) {
     $dn = $entry_dn;
+} elseif (isset($_SESSION["entry_dn"])) {
+    $dn = $_SESSION["entry_dn"];
 } else {
     $result = "dnrequired";
 }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -106,14 +106,14 @@ $page = "login";// Default route to login page
 if ( $authenticated ) { $page = "display"; }// If authenticated, route to display
 if ( isset($_GET["page"]) and $_GET["page"] and !$authenticated) { $page = "login"; }// If not authenticated, route to login
 if ( isset($_GET["page"])  and $_GET["page"] and $_GET["page"] != "login" and $authenticated) { $page = $_GET["page"]; }
-if ( $page === "checkpassword" and (!$use_checkpassword or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "resetpassword" and (!$use_resetpassword or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "unlockaccount" and (!$use_unlockaccount or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "search" and !$isadmin ) { $page = "welcome"; }
-if ( $page === "searchlocked" and (!$use_searchlocked or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "searchexpired" and (!$use_searchexpired or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "searchwillexpire" and (!$use_searchwillexpire or !$isadmin) ) { $page = "welcome"; }
-if ( $page === "searchidle" and (!$use_searchidle or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "checkpassword" and (!$use_checkpassword or !$isadmin) ) { $page = "display"; }
+if ( $page === "resetpassword" and (!$use_resetpassword or !$isadmin) ) { $page = "display"; }
+if ( $page === "unlockaccount" and (!$use_unlockaccount or !$isadmin) ) { $page = "display"; }
+if ( $page === "search" and !$isadmin ) { $page = "display"; }
+if ( $page === "searchlocked" and (!$use_searchlocked or !$isadmin) ) { $page = "display"; }
+if ( $page === "searchexpired" and (!$use_searchexpired or !$isadmin) ) { $page = "display"; }
+if ( $page === "searchwillexpire" and (!$use_searchwillexpire or !$isadmin) ) { $page = "display"; }
+if ( $page === "searchidle" and (!$use_searchidle or !$isadmin) ) { $page = "display"; }
 if ( file_exists($page.".php") ) { require_once($page.".php"); }
 $smarty->assign('page',$page);
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -106,8 +106,8 @@ $page = "login";// Default route to login page
 if ( $authenticated ) { $page = "display"; }// If authenticated, route to display
 if ( isset($_GET["page"]) and $_GET["page"] and !$authenticated) { $page = "login"; }// If not authenticated, route to login
 if ( isset($_GET["page"])  and $_GET["page"] and $_GET["page"] != "login" and $authenticated) { $page = $_GET["page"]; }
-if ( $page === "checkpassword" and (!$use_checkpassword or !$isadmin) ) { $page = "display"; }
-if ( $page === "resetpassword" and (!$use_resetpassword or !$isadmin) ) { $page = "display"; }
+if ( $page === "checkpassword" and !$use_checkpassword ) { $page = "display"; }
+if ( $page === "resetpassword" and !$use_resetpassword ) { $page = "display"; }
 if ( $page === "unlockaccount" and (!$use_unlockaccount or !$isadmin) ) { $page = "display"; }
 if ( $page === "search" and !$isadmin ) { $page = "display"; }
 if ( $page === "searchlocked" and (!$use_searchlocked or !$isadmin) ) { $page = "display"; }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -91,11 +91,18 @@ $smarty->registerPlugin("function", "convert_bytes", "convert_bytes");
 # Authentication
 #==============================================================================
 require_once("../lib/login.php"); //Maintains session variables
-$authenticated = $_SESSION["authenticated"];
-$isadmin = $_SESSION['isadmin'];
+if ( !$ldap_authentication ) {// If authentication is disabled by configuration
+    $isadmin = $_SESSION["authenticated"] = true;
+    $authenticated = $_SESSION["isadmin"] = true;
+} else {
+    $authenticated = $_SESSION["authenticated"];
+    $isadmin = $_SESSION['isadmin'];
+}
+
 $smarty->assign('authenticated',$_SESSION["authenticated"]);
 $smarty->assign('isadmin',$_SESSION["isadmin"]);
 $smarty->assign('displayname',$_SESSION["displayname"]);
+$smarty->assign('ldap_authentication',$ldap_authentication);
 
 #==============================================================================
 # Route to page

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -88,11 +88,23 @@ $smarty->registerPlugin("function", "convert_ldap_date", "convert_ldap_date");
 $smarty->registerPlugin("function", "convert_bytes", "convert_bytes");
 
 #==============================================================================
+# Authentication
+#==============================================================================
+require_once("../lib/login.php"); //Maintains session variables
+$authenticated = $_SESSION["authenticated"];
+$smarty->assign('authenticated',$_SESSION["authenticated"]);
+$smarty->assign('isadmin',$_SESSION["isadmin"]);
+$smarty->assign('displayname',$_SESSION["displayname"]);
+
+#==============================================================================
 # Route to page
 #==============================================================================
 $result = "";
-$page = "welcome";
-if (isset($_GET["page"]) and $_GET["page"]) { $page = $_GET["page"]; }
+$page = "login";// Default route to login page
+
+if ( $authenticated ) { $page = "display"; }// If authenticated, route to display
+if ( isset($_GET["page"]) and $_GET["page"] and !$authenticated) { $page = "login"; }// If not authenticated, route to login
+if ( isset($_GET["page"])  && $_GET["page"] && $_GET["page"] != "login" && $authenticated) { $page = $_GET["page"]; }
 if ( $page === "checkpassword" and !$use_checkpassword ) { $page = "welcome"; }
 if ( $page === "resetpassword" and !$use_resetpassword ) { $page = "welcome"; }
 if ( $page === "unlockaccount" and !$use_unlockaccount ) { $page = "welcome"; }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -92,6 +92,7 @@ $smarty->registerPlugin("function", "convert_bytes", "convert_bytes");
 #==============================================================================
 require_once("../lib/login.php"); //Maintains session variables
 $authenticated = $_SESSION["authenticated"];
+$isadmin = $_SESSION['isadmin'];
 $smarty->assign('authenticated',$_SESSION["authenticated"]);
 $smarty->assign('isadmin',$_SESSION["isadmin"]);
 $smarty->assign('displayname',$_SESSION["displayname"]);
@@ -104,14 +105,15 @@ $page = "login";// Default route to login page
 
 if ( $authenticated ) { $page = "display"; }// If authenticated, route to display
 if ( isset($_GET["page"]) and $_GET["page"] and !$authenticated) { $page = "login"; }// If not authenticated, route to login
-if ( isset($_GET["page"])  && $_GET["page"] && $_GET["page"] != "login" && $authenticated) { $page = $_GET["page"]; }
-if ( $page === "checkpassword" and !$use_checkpassword ) { $page = "welcome"; }
-if ( $page === "resetpassword" and !$use_resetpassword ) { $page = "welcome"; }
-if ( $page === "unlockaccount" and !$use_unlockaccount ) { $page = "welcome"; }
-if ( $page === "searchlocked" and !$use_searchlocked ) { $page = "welcome"; }
-if ( $page === "searchexpired" and !$use_searchexpired ) { $page = "welcome"; }
-if ( $page === "searchwillexpire" and !$use_searchwillexpire ) { $page = "welcome"; }
-if ( $page === "searchidle" and !$use_searchidle ) { $page = "welcome"; }
+if ( isset($_GET["page"])  and $_GET["page"] and $_GET["page"] != "login" and $authenticated) { $page = $_GET["page"]; }
+if ( $page === "checkpassword" and (!$use_checkpassword or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "resetpassword" and (!$use_resetpassword or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "unlockaccount" and (!$use_unlockaccount or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "search" and !$isadmin ) { $page = "welcome"; }
+if ( $page === "searchlocked" and (!$use_searchlocked or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "searchexpired" and (!$use_searchexpired or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "searchwillexpire" and (!$use_searchwillexpire or !$isadmin) ) { $page = "welcome"; }
+if ( $page === "searchidle" and (!$use_searchidle or !$isadmin) ) { $page = "welcome"; }
 if ( file_exists($page.".php") ) { require_once($page.".php"); }
 $smarty->assign('page',$page);
 

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -1,14 +1,20 @@
 <?php
 
+// Continue session variables
+session_start();
+$displayname = $_SESSION["displayname"];
+
 #==============================================================================
 # English
 #==============================================================================
 
+$messages["label_created"] = "Created";
+$messages["label_modified"] = "Modified";
 $messages['accountlocked'] = "Account is locked";
 $messages['accountnotlocked'] = "Fail to lock account";
 $messages['accountnotunlocked'] = "Fail to unlock account";
-$messages['accountunlocked'] = "Account is not locked";
 $messages['accountstatus'] = "Account status";
+$messages['accountunlocked'] = "Account is not locked";
 $messages['checkpassword'] = "Check password";
 $messages['currentpassword'] = "Current password";
 $messages['dashboards'] = "Dashboards";
@@ -22,13 +28,9 @@ $messages['false'] = "No";
 $messages['forcereset'] = "Force reset at next connection";
 $messages['idleaccounts'] = "Idle accounts";
 $messages['idleaccountstitle'] = "Accounts idle for more than $idledays days";
-$messages['pager_all'] = "All";
-$messages['print_all'] = "Print all results";
-$messages['print_page'] = "Print this page";
 $messages['label_authtimestamp'] = "Last authentication";
 $messages['label_businesscategory'] = "Business category";
 $messages['label_carlicense'] = "Car license";
-$messages["label_created"] = "Created";
 $messages['label_description'] = "Description";
 $messages['label_displayname'] = "Display name";
 $messages['label_employeenumber'] = "Employee number";
@@ -43,7 +45,6 @@ $messages['label_lastname'] = "Last name";
 $messages['label_mail'] = "Mail";
 $messages['label_mailquota'] = "Mail quota";
 $messages['label_mobile'] = "Mobile";
-$messages["label_modified"] = "Modified";
 $messages['label_organization'] = "Organization";
 $messages['label_organizationalunit'] = "Organizational Unit";
 $messages['label_pager'] = "Pager";
@@ -60,17 +61,21 @@ $messages['label_title'] = "Title";
 $messages['ldaperror'] = "LDAP communication error";
 $messages['lockaccount'] = "Lock account";
 $messages['lockedaccounts'] = "Locked accounts";
+$messages['login'] = "Please login to continue";
 $messages['logout'] = "Logout";
 $messages['newpassword'] = "New password";
 $messages['noentriesfound'] = "No entries found";
 $messages['notdefined'] = "Not defined";
+$messages['pager_all'] = "All";
 $messages['password'] = "Password";
 $messages['passwordchanged'] = "Password changed";
 $messages['passwordexpired'] = "Password is expired";
 $messages['passwordinvalid'] = "Authentication has failed";
 $messages['passwordok'] = "Authentication succeeds!";
-$messages['passwordrefused'] = "Password was refused";
-$messages['passwordrequired'] = "Please enter the password";
+$messages['passwordrefused'] = "Password is incorrect";
+$messages['passwordrequired'] = "Please enter a password";
+$messages['print_all'] = "Print all results";
+$messages['print_page'] = "Print this page";
 $messages['resetpassword'] = "Reset password";
 $messages['search'] = "Search";
 $messages['searchrequired'] = "Please enter your search";
@@ -83,7 +88,12 @@ $messages['tooltip_phoneto'] = "Dial this number";
 $messages['true'] = "Yes";
 $messages['unlockaccount'] = "Unlock account";
 $messages['unlockdate'] = "Automatic unlock date:";
+$messages['username'] = "Username";
+$messages['usernamerequired'] = "Please enter a username";
+$messages['usernotallowed'] = "Your account is not allowed to login. Please use an authorized account.";
+$messages['usernotfound'] = "The entered username was not found. Please try again.";
 $messages['welcome'] = "Welcome to LDAP Tool Box service desk";
+$messages['welcomeuser'] = "Welcome, $displayname";
 $messages['willexpireaccounts'] = "Passwords soon expired";
 $messages['willexpireaccountstitle'] = "Passwords that will expire within $willexpiredays days";
 

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -1,9 +1,15 @@
 <?php
 
+// Continue session variables
+session_start();
+$displayname = $_SESSION["displayname"];
+
 #==============================================================================
 # French
 #==============================================================================
 
+$messages["label_created"] = "Créé";
+$messages["label_modified"] = "Modifié";
 $messages['accountlocked'] = "Le compte est bloqué";
 $messages['accountnotlocked'] = "Échec de blocage du compte";
 $messages['accountnotunlocked'] = "Échec de déblocage du compte";
@@ -22,13 +28,9 @@ $messages['false'] = "Non";
 $messages['forcereset'] = "Forcer la réinitialisation à la prochaine connexion";
 $messages['idleaccounts'] = "Comptes inactifs";
 $messages['idleaccountstitle'] = "Comptes inactifs depuis plus de $idledays jours";
-$messages['pager_all'] = "Tout";
-$messages['print_all'] = "Imprimer tous les résultats";
-$messages['print_page'] = "Imprimer cette page";
 $messages['label_authtimestamp'] = "Dernière authentification";
 $messages['label_businesscategory'] = "Catégorie";
 $messages['label_carlicense'] = "Permis de conduire";
-$messages["label_created"] = "Créé";
 $messages['label_description'] = "Description";
 $messages['label_displayname'] = "Nom d'affichage";
 $messages['label_employeenumber'] = "Numéro d'employé";
@@ -43,7 +45,6 @@ $messages['label_lastname'] = "Nom";
 $messages['label_mail'] = "Courriel";
 $messages['label_mailquota'] = "Quota messagerie";
 $messages['label_mobile'] = "Portable";
-$messages["label_modified"] = "Modifié";
 $messages['label_organization'] = "Organisation";
 $messages['label_organizationalunit'] = "Service";
 $messages['label_pager'] = "Messagerie";
@@ -60,10 +61,12 @@ $messages['label_title'] = "Titre";
 $messages['ldaperror'] = "Erreur de communication avec l'annuaire LDAP";
 $messages['lockaccount'] = "Bloquer le compte";
 $messages['lockedaccounts'] = "Comptes bloqués";
+$messages['login'] = "Veuillez vous connecter pour continuer";
 $messages['logout'] = "Déconnexion";
 $messages['newpassword'] = "Nouveau mot de passe";
 $messages['noentriesfound'] = "Aucune entrée trouvée";
 $messages['notdefined'] = "Non renseigné";
+$messages['pager_all'] = "Tout";
 $messages['password'] = "Mot de passe";
 $messages['passwordchanged'] = "Le mot de passe a été changé";
 $messages['passwordexpired'] = "Le mot de passe est expiré";
@@ -71,6 +74,8 @@ $messages['passwordinvalid'] = "Authentification en échec";
 $messages['passwordok'] = "Authentification réussie !";
 $messages['passwordrefused'] = "Le mot de passe a été refusé";
 $messages['passwordrequired'] = "Merci de saisir le mot de passe";
+$messages['print_all'] = "Imprimer tous les résultats";
+$messages['print_page'] = "Imprimer cette page";
 $messages['resetpassword'] = "Réinitialisation du mot de passe";
 $messages['search'] = "Rechercher";
 $messages['searchrequired'] = "Veuillez saisir votre recherche";
@@ -83,7 +88,12 @@ $messages['tooltip_phoneto'] = "Composer ce numéro";
 $messages['true'] = "Oui";
 $messages['unlockaccount'] = "Débloquer le compte";
 $messages['unlockdate'] = "Date de déblocage automatique :";
+$messages['username'] = "Username";
+$messages['usernamerequired'] = "Merci d'entrer un username";
+$messages['usernotallowed'] = "Votre compte n'est pas autorisé à se connecter. Veuillez utiliser un compte autorisé.";
+$messages['usernotfound'] = "Le nom d'utilisateur saisi est introuvable. Veuillez réessayer.";
 $messages['welcome'] = "Bienvenue sur le guichet de service LDAP Tool Box";
+$messages['welcomeuser'] = "Bienvenue, $displayname";
 $messages['willexpireaccounts'] = "Mots de passe bientôt expirés";
 $messages['willexpireaccountstitle'] = "Mots de passe allant expirer dans moins de $willexpiredays jours";
 

--- a/lib/login.php
+++ b/lib/login.php
@@ -1,0 +1,178 @@
+<?php
+/*
+ * Authentication Handling
+ */
+
+// Declare volatile variables
+$autherror = "";
+$dn = "";
+$displayname = "";
+$memberOf = "";
+$ou = "";
+$username = "";
+$password = "";
+$search_query = "";
+$entries = array();
+
+// Sensitive authentication variables:
+// These should be cleared each time login.php is called.
+$authenticated = false;
+$isadmin = false;
+
+// Verify that timezone is correct
+date_default_timezone_set('America/Denver');
+
+// Continue session variables
+session_start();
+
+
+
+// Logon was requested.
+if(isset($_POST["username"]) and isset($_POST["password"])) {
+    
+    $username = strtolower($_POST["username"]);
+    $password = $_POST["password"];
+    
+    // Input validations
+    if(!empty($_POST["username"]) and !empty($_POST["password"])) {
+        $autherror = logon($username, $password);// Do the login
+        $_SESSION["authenticated"] = (!strcmp($autherror,"authsuccess")? true: false);// Log user out should any other condition fail
+    }
+    elseif (empty($_POST["username"])) {// Username field is empty
+        $autherror = "usernamerequired";
+    }
+    elseif (empty($_POST["password"])) {// Password field is empty
+        $autherror = "passwordrequired";
+    }
+    $smarty->assign('autherror',$autherror);// Pass any error code to Smarty
+
+}
+
+
+
+
+// Logoff if was requested.
+if(isset($_POST["logoff"]) and $_POST["logoff"]){
+    logoff();
+}
+
+
+
+
+function logon( $username, $password) {
+
+    # Connect to LDAP
+    require("../conf/config.inc.php");
+    require_once("../lib/ldap.inc.php");
+
+    # Connect to LDAP
+    $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw);
+
+    $ldap = $ldap_connection[0];
+
+    if ($ldap) {
+
+        # Search filter
+        $ldap_filter = "(&".$ldap_user_filter."(|";
+        foreach ($search_attributes as $attr) {
+            $ldap_filter .= "(".$attr."=".$username.")";
+        }
+        $ldap_filter .= "))";
+
+        # Search attributes
+        $attributes = array("dn", "cn", "surname", "givenname", "mail", "memberOf", "msds-parentdistname", "uid", "samaccountname");
+
+        # Search for users
+        $search = ldap_search($ldap, $ldap_user_base, $ldap_filter, $attributes, 0, $ldap_size_limit);
+        $errno = ldap_errno($ldap);
+
+        if ( $errno != 0 ) {// If there's an ldap error, stop here.
+
+            $autherror = "LDAP Search error " . $errno . " (" . ldap_error($ldap) . ")";
+            error_log("LDAP Search error $errno  (".ldap_error($ldap).")");
+
+        } else {// Else get the entries
+            
+            $entries = ldap_get_entries($ldap, $search);
+            // echo "Entries: "; print_r($entries); echo "<br>";
+
+            if ( $entries['count'] === 1 ) {// Check for only one result
+
+                $dn = $entries[0]['dn'];// Save distinguished name
+                $ou = $entries[0]['msds-parentdistname'][0];// Save organizational unit
+                $uid = ( !empty($entries[0]['samaccountname'][0]) ? $entries[0]['samaccountname'][0] : $entries[0]['uid'][0] );
+                // echo "UID: $uid<br>";
+                $displayname = $entries[0]['cn'][0];// Save display name
+                $memberOf = $entries[0]['memberof'];// Save group memberships
+
+                if ( !in_array(strtolower($ou), array_map('strtolower', $ldap_disallowed_ous)) ) {// Check if in allowed Organizational Unit
+                    
+                    $bind = ldap_bind($ldap, $dn, $password);// Bind to LDAP given $dn and $password
+
+                    if ($bind) {// Log them in only if LDAP bind succeeds
+                        $autherror = "authsuccess";
+                    } else {
+                        $autherror = "passwordrefused";
+                    }
+                } else {
+                    $autherror = "usernotallowed";
+                }
+
+            } elseif ( $entries['count'] > 1 ) {
+                $autherror = "notoneunique";// Too many entries returned
+            } else {
+                $autherror = "usernotfound";// User not found
+            }
+        }
+    }
+
+    // Admin Checks
+    $admincheck1 = ( isset($ldap_allowed_admin_users) and in_array(strtolower($uid), array_map('strtolower', $ldap_allowed_admin_users)) ? true : false );
+    $admincheck2 = ( isset($ldap_allowed_admin_ous) and in_array(strtolower($ou), array_map('strtolower', $ldap_allowed_admin_ous)) ? true : false );
+    $admincheck3 = ( isset($ldap_allowed_admin_groups) and array_in_array($memberOf, array_map('strtolower', $ldap_allowed_admin_groups)) ? true : false );
+    $isadmin = (( $admincheck1 or $admincheck2 or $admincheck3 ) ? true : false );// If any above conditions are met, set the user to be an admin.
+    
+    // Update Session Variables
+    $_SESSION["username"] = $username;
+    $_SESSION["displayname"] = $displayname;
+    $_SESSION["isadmin"] = $isadmin;
+    $_SESSION["entry_dn"] = $dn;
+
+    return $autherror;
+	    
+}// End logon()
+
+
+
+function logoff() {
+	// Unset all of the session variables.
+	$_SESSION = array();
+
+	// If it's desired to kill the session, also delete the session cookie.
+	// Note: This will destroy the session, and not just the session data!
+	if (ini_get("session.use_cookies")) {
+		$params = session_get_cookie_params();
+		setcookie(session_name(), '', time() - 42000,
+			$params["path"], $params["domain"],
+			$params["secure"], $params["httponly"]
+		);
+	}
+	session_destroy();
+
+}// End logoff()
+
+
+
+// Multi-dimensional array comparison
+function array_in_array($a, $b) {
+    foreach ($a as $item) {
+        if ( in_array( strtolower($item), $b) ) {
+            return true;
+        }
+    }
+    return false;
+}// End in_array_r()
+
+
+
+?>

--- a/lib/login.php
+++ b/lib/login.php
@@ -16,7 +16,6 @@ $entries = array();
 
 // Sensitive authentication variables:
 // These should be cleared each time login.php is called.
-$authenticated = false;
 $isadmin = false;
 
 // Verify that timezone is correct

--- a/lib/login.php
+++ b/lib/login.php
@@ -68,6 +68,7 @@ function logon( $username, $password) {
     $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw);
 
     $ldap = $ldap_connection[0];
+    $result = $ldap_connection[1];
 
     if ($ldap) {
 
@@ -123,19 +124,23 @@ function logon( $username, $password) {
                 $autherror = "usernotfound";// User not found
             }
         }
-    }
 
-    // Admin Checks
-    $admincheck1 = ( isset($ldap_allowed_admin_users) and in_array(strtolower($uid), array_map('strtolower', $ldap_allowed_admin_users)) ? true : false );
-    $admincheck2 = ( isset($ldap_allowed_admin_ous) and in_array(strtolower($ou), array_map('strtolower', $ldap_allowed_admin_ous)) ? true : false );
-    $admincheck3 = ( isset($ldap_allowed_admin_groups) and array_in_array($memberOf, array_map('strtolower', $ldap_allowed_admin_groups)) ? true : false );
-    $isadmin = (( $admincheck1 or $admincheck2 or $admincheck3 ) ? true : false );// If any above conditions are met, set the user to be an admin.
-    
-    // Update Session Variables
-    $_SESSION["username"] = $username;
-    $_SESSION["displayname"] = $displayname;
-    $_SESSION["isadmin"] = $isadmin;
-    $_SESSION["entry_dn"] = $dn;
+        // Admin Checks
+        $admincheck1 = ( isset($ldap_allowed_admin_users) and in_array(strtolower($uid), array_map('strtolower', $ldap_allowed_admin_users)) ? true : false );
+        $admincheck2 = ( isset($ldap_allowed_admin_ous) and in_array(strtolower($ou), array_map('strtolower', $ldap_allowed_admin_ous)) ? true : false );
+        $admincheck3 = ( isset($ldap_allowed_admin_groups) and array_in_array($memberOf, array_map('strtolower', $ldap_allowed_admin_groups)) ? true : false );
+        $isadmin = (( $admincheck1 or $admincheck2 or $admincheck3 ) ? true : false );// If any above conditions are met, set the user to be an admin.
+        
+        // Update Session Variables
+        $_SESSION["username"] = $username;
+        $_SESSION["displayname"] = $displayname;
+        $_SESSION["isadmin"] = $isadmin;
+        $_SESSION["entry_dn"] = $dn;
+
+    } else {
+        $autherror = "LDAP connection error";
+        error_log("LDAP connection error");
+    }
 
     return $autherror;
 	    

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -1,3 +1,11 @@
+
+{if empty($entry) or $entry.count eq 0} {* If there are no entries to be displayed, show welcome page *}
+<a href="index.php">
+    <img src="{$logo}" alt="{$msg_title}" class="logo img-responsive center-block" />
+</a>
+
+<div class="alert alert-success">{$msg_welcome}</div>
+{else} {* Else display the entry *}
 <div class="row">
     <div class="display col-md-6">
 
@@ -268,3 +276,4 @@
         {/if}
    </div>
 </div>
+{/if}

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -99,7 +99,7 @@
     </div>
     <div class="col-md-6">
 
-        {if $use_checkpassword}
+        {if $use_checkpassword and $isadmin and $displayname neq $entry.cn.0}
         <div class="panel panel-info">
             <div class="panel-heading text-center">
                 <p class="panel-title">

--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -9,28 +9,10 @@
  <div class="panel-body">
 
      <form id="login" method="post" action="index.php?page=login" name="login">
-         {if $autherror eq 'usernotfound'}
-            <div class="alert alert-warning"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernotfound}</div>
-         {/if}
-         {if $autherror eq 'passwordrefused'}
-            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_passwordrefused}</div>
-         {/if}
-         {if $autherror eq 'usernotallowed'}
-            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernotallowed}</div>
-         {/if}
-         {if $autherror eq 'usernamerequired'}
-            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernamerequired}</div>
-         {/if}
-         {if $autherror eq 'passwordrequired'}
-            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_passwordrequired}</div>
-         {/if}
-         {if $autherror neq 'passwordrefused' 
-         and $autherror neq 'passwordrequired' 
-         and $autherror neq 'usernotfound' 
-         and $autherror neq 'usernamerequired'
-         and $autherror neq 'usernotallowed'
-         and $autherror neq ''}
-            <div class="alert alert-warning"><i class="fa fa-fw fa-exclamation-triangle"></i> There was an error: {$autherror}</div>
+         {if $autherror neq '' and isset($msg_{$autherror})}
+            <div class="alert alert-warning"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_{$autherror}}</div>
+         {elseif $autherror neq ''}
+            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> Error: {$autherror}</div>
          {/if}
          <div class="form-group">
              <div class="input-group">

--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -1,0 +1,54 @@
+<div class="panel panel-info">
+<div class="panel-heading text-center">
+    <p class="panel-title">
+        <i class="fa fa-fw fa-check-circle"></i>
+        {$msg_login}
+    </p>
+</div>
+
+ <div class="panel-body">
+
+     <form id="login" method="post" action="index.php?page=login" name="login">
+         {if $autherror eq 'usernotfound'}
+            <div class="alert alert-warning"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernotfound}</div>
+         {/if}
+         {if $autherror eq 'passwordrefused'}
+            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_passwordrefused}</div>
+         {/if}
+         {if $autherror eq 'usernotallowed'}
+            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernotallowed}</div>
+         {/if}
+         {if $autherror eq 'usernamerequired'}
+            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_usernamerequired}</div>
+         {/if}
+         {if $autherror eq 'passwordrequired'}
+            <div class="alert alert-danger"><i class="fa fa-fw fa-exclamation-triangle"></i> {$msg_passwordrequired}</div>
+         {/if}
+         {if $autherror neq 'passwordrefused' 
+         and $autherror neq 'passwordrequired' 
+         and $autherror neq 'usernotfound' 
+         and $autherror neq 'usernamerequired'
+         and $autherror neq 'usernotallowed'
+         and $autherror neq ''}
+            <div class="alert alert-warning"><i class="fa fa-fw fa-exclamation-triangle"></i> There was an error: {$autherror}</div>
+         {/if}
+         <div class="form-group">
+             <div class="input-group">
+                 <span class="input-group-addon"><i class="fa fa-fw fa-user"></i></span>
+                <input type="username" name="username" id="username" class="form-control" placeholder="{$msg_username}" />
+             </div>
+         </div>
+         <div class="form-group">
+            <div class="input-group">
+                <span class="input-group-addon"><i class="fa fa-fw fa-lock"></i></span>
+                <input type="password" name="password" id="password" class="form-control" placeholder="{$msg_password}" />
+            </div>
+         </div>
+         <div class="form-group">
+            <button type="submit" class="btn btn-success">
+                <i class="fa fa-fw fa-check-square-o"></i> {$msg_submit}
+            </button>
+         </div>
+    </form>
+</div>
+</div>

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -1,59 +1,68 @@
-    <div class="navbar-wrapper">
+<div class="navbar-wrapper">
 
-        <div class="navbar navbar-default navbar-static-top" role="navigation">
-          <div class="container-fluid">
-            <div class="navbar-header">
-              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-              </button>
-              <a class="navbar-brand" href="index.php?page=welcome">
-                {if $logo}
-                <img src="{$logo}" alt="Logo" class="menu-logo img-responsive" />
-                {/if}
-                {$msg_title}
-              </a>
-            </div>
-            <div class="navbar-collapse collapse">
-              <ul class="nav navbar-nav">
-                {if $use_searchlocked or $use_searchwillexpire or $use_searchexpired or $use_searchidle}
-                <li class="dropdown">
-                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-fw fa-dashboard"></i> {$msg_dashboards}<span class="caret"></span></a>
-                    <ul class="dropdown-menu">
-                      {if $use_searchlocked}
-                      <li><a href="index.php?page=searchlocked"><i class="fa fa-fw fa-lock"></i> {$msg_lockedaccounts}</a></li>
-                      {/if}
-                      {if $use_searchwillexpire}
-                      <li><a href="index.php?page=searchwillexpire"><i class="fa fa-fw fa-hourglass-half"></i> {$msg_willexpireaccounts}</a></li>
-                      {/if}
-                      {if $use_searchexpired}
-                      <li><a href="index.php?page=searchexpired"><i class="fa fa-fw fa-hourglass-end"></i> {$msg_expiredaccounts}</a></li>
-                      {/if}
-                      {if $use_searchidle}
-                      <li><a href="index.php?page=searchidle"><i class="fa fa-fw fa-hourglass-o"></i> {$msg_idleaccounts}</a></li>
-                      {/if}
-                    </ul>
-                  </a>
-                </li>
-                {/if}
-                {if $logout_link}
-                <li>
-                  <a href="{$logout_link}"><i class="fa fa-fw fa-sign-out"></i> {$msg_logout}</a>
-                </li>
-                {/if}
-              </ul>
-              <form class="navbar-form navbar-right" role="search" action="index.php?page=search" method="post">
-                <div class="input-group">
-                  <input type="text" class="form-control" placeholder="{$msg_search}" name="search" value="{$search}" />
-                  <span class="input-group-btn">
-                    <button class="btn btn-default" type="submit">&nbsp;<i class="fa fa-fw fa-search"></i></button>
-                  </span>
-                </div>
-              </form>
-            </div>
-          </div>
+    <div class="navbar navbar-default navbar-static-top" role="navigation">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="index.php">
+            {if $logo}
+            <img src="{$logo}" alt="Logo" class="menu-logo img-responsive" />
+            {else}
+            {$msg_title}
+            {/if}
+          </a>
         </div>
-
+        <div class="navbar-collapse collapse">
+          <ul class="nav navbar-nav">
+            {if $isadmin and ($use_searchlocked or $use_searchwillexpire or $use_searchexpired or $use_searchidle)}
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-fw fa-dashboard"></i> {$msg_dashboards}<span class="caret"></span></a>
+                <ul class="dropdown-menu">
+                  {if $use_searchlocked}
+                  <li><a href="index.php?page=searchlocked"><i class="fa fa-fw fa-lock"></i> {$msg_lockedaccounts}</a></li>
+                  {/if}
+                  {if $use_searchwillexpire}
+                  <li><a href="index.php?page=searchwillexpire"><i class="fa fa-fw fa-hourglass-half"></i> {$msg_willexpireaccounts}</a></li>
+                  {/if}
+                  {if $use_searchexpired}
+                  <li><a href="index.php?page=searchexpired"><i class="fa fa-fw fa-hourglass-end"></i> {$msg_expiredaccounts}</a></li>
+                  {/if}
+                  {if $use_searchidle}
+                  <li><a href="index.php?page=searchidle"><i class="fa fa-fw fa-hourglass-o"></i> {$msg_idleaccounts}</a></li>
+                  {/if}
+                </ul>
+              </a>
+            </li>
+            {/if}
+          </ul>
+          <form class="navbar-form navbar-right" action="index.php?page=login" method="post">
+            <div class="form-group">
+              <button type="submit" class="btn btn-success" name="logoff" value="yes">
+                <i class="fa fa-fw fa-sign-out"></i> {$msg_logout}
+              </button>
+            </div>
+          </form>
+          {if $isadmin }
+            <form class="navbar-form navbar-right" role="search" action="index.php?page=search" method="post">
+              <div class="input-group">
+                <input type="text" class="form-control" placeholder="{$msg_search}" name="search" value="{$search}" />
+                <span class="input-group-btn">
+                  <button class="btn btn-default" type="submit">&nbsp;<i class="fa fa-fw fa-search"></i></button>
+                </span>
+              </div>
+            </form>
+          {/if}
+        </div>
+      </div>
     </div>
+</div>
+{if $authenticated and $page eq "display"}
+<div class="alert alert-success"><i class="fa fa-fw fa-info-circle"></i> Welcome, {$displayname}.
+{if $isadmin}<span style="float: right;"> You have admin privileges.</span>{/if}
+</div>
+{/if}

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -40,6 +40,7 @@
             </li>
             {/if}
           </ul>
+          {if $ldap_authentication}
           <form class="navbar-form navbar-right" action="index.php?page=login" method="post">
             <div class="form-group">
               <button type="submit" class="btn btn-success" name="logoff" value="yes">
@@ -47,6 +48,7 @@
               </button>
             </div>
           </form>
+          {/if}
           {if $isadmin }
             <form class="navbar-form navbar-right" role="search" action="index.php?page=search" method="post">
               <div class="input-group">
@@ -61,7 +63,7 @@
       </div>
     </div>
 </div>
-{if $authenticated and $page eq "display"}
+{if $ldap_authentication and $authenticated and $page eq "display"}
 <div class="alert alert-success"><i class="fa fa-fw fa-info-circle"></i> Welcome, {$displayname}.
 {if $isadmin}<span style="float: right;"> You have admin privileges.</span>{/if}
 </div>

--- a/templates/welcome.tpl
+++ b/templates/welcome.tpl
@@ -1,5 +1,0 @@
-<a href="index.php">
-    <img src="{$logo}" alt="{$msg_title}" class="logo img-responsive center-block" />
-</a>
-
-<div class="alert alert-success">{$msg_welcome}</div>


### PR DESCRIPTION
I have added password-protection to the Service-Desk website using in-place LDAP authentication. This PR can be merged as-is, ~~however I am still working on giving users ability to edit some of their LDAP attributes, as specified by the config~~.
![image](https://user-images.githubusercontent.com/9312603/190237162-83061947-d788-4ec9-9273-97b36ac855a9.png)

The summary of added functionality is as follows:
- A basic user can log in and view attributes for their own account, or change their password.
- Admin users can log in and view attributes for everybody's accounts, and check/change their passwords.
- Admin users have access to the dashboard and search menus, basic accounts do not.
- Website managers can specify who can and cannot login, as well as who has elevated privileges to edit accounts other than their own by setting authentication variables in config.inc.php. Please review config.inc.php for list of proposed authentication variables where an administrator can have granular control over access.

Added Functionality:
- [x] Basic site-wide authentication functionality. Users must be logged in to view attributes and change passwords.
- [x] Basic users can log in and view only their own LDAP attributes.
- [x] Admin users can log in and view everybody's LDAP attributes.
~~Ability for basic users to easily edit all or most of their own LDAP attributes, such as 'mobile' or 'displayname'.~~
~~Ability for admins easily to edit all users' LDAP attributes.~~

I have tested this in an Active Directory LDAP environment, however this needs testing in a purely LDAP environment as well.

Quality Control:
- [x] Testing in Active Directory environment.
- [ ] Testing in LDAP environment.
- [ ] Verify my French translations make sense.