### PR TITLE
Document required installation step for smarty3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,7 +52,7 @@ You are now ready to install:
 
 .. prompt:: bash #
 
-    apt install service-desk
+    apt install service-desk smarty3
 
 CentOS / RedHat
 ---------------


### PR DESCRIPTION
I'm not sure why smarty3 is not a dependancy of the debian package, but it seems like a deliberate choice (092e0525f80a8f1ab293d4bf8095bc695e2d3632)

Either way, we should at least mention in debian installation docs that it is required