### PR TITLE
Fix the comment required feature

### DIFF
--- a/templates/comment.tpl
+++ b/templates/comment.tpl
@@ -8,13 +8,7 @@
                     <h1 class="modal-title fs-5" id="CommentModal">{$title}</h1>
                 </div>
                 <div class="modal-body">
-                    <textarea class="form-control" name="comment" id="comment-{$method}" rows="3" placeholder="{$msg_insert_comment}"
-                    {if $method eq 'lock' || $method eq 'unlock'}
-                        {if $use_lockcomment_required || $use_unlockcomment_required}required{/if}
-                    {elseif $method eq 'enable' || $method eq 'disable'}
-                        {if $use_disablecomment_required || $use_enablecomment_required}required{/if}
-                    {/if}
-                    ></textarea>
+                    <textarea class="form-control" name="comment" id="comment-{$method}" rows="3" placeholder="{$msg_insert_comment}"{if $required} required{/if}></textarea>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -247,7 +247,7 @@
                         <i class="fa fa-fw fa-info-circle text-body-tertiary ms-2" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=unlock page=unlockaccount title=$msg_unlockaccount}
+                        {include 'comment.tpl' method=unlock page=unlockaccount title=$msg_unlockaccount required=$use_unlockcomment_required}
                     </div>
                 {else}
                     <form id="unlockaccount" method="post" action="index.php?page=unlockaccount">
@@ -282,7 +282,7 @@
                         <i class="fa fa-fw fa-info-circle text-body-tertiary ms-2" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=lock page=lockaccount title=$msg_lockaccount}
+                        {include 'comment.tpl' method=lock page=lockaccount title=$msg_lockaccount required=$use_lockcomment_required}
                     </div>
                 {else}
                     <form id="lockaccount" method="post" action="index.php?page=lockaccount">
@@ -331,7 +331,7 @@
                         <i class="fa fa-fw fa-info-circle text-body-tertiary ms-2" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=disable page=disableaccount title=$msg_disableaccount}
+                        {include 'comment.tpl' method=disable page=disableaccount title=$msg_disableaccount required=$use_disablecomment_required}
                     </div>
                 {else}
                     <form id="disableaccount" method="post" action="index.php?page=disableaccount">
@@ -363,7 +363,7 @@
                         <i class="fa fa-fw fa-info-circle text-body-tertiary ms-2" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=enable page=enableaccount title=$msg_enableaccount}
+                        {include 'comment.tpl' method=enable page=enableaccount title=$msg_enableaccount required=$use_enablecomment_required}
                     </div>
                 {else}
                     <form id="disableaccount" method="post" action="index.php?page=enableaccount">

--- a/templates/listing_table.tpl
+++ b/templates/listing_table.tpl
@@ -17,11 +17,11 @@
             {if $display_unlock_button}
                 {if $use_unlockcomment}
                     <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#commentModalunlock{$entry.dn|sha256}">
-                        <i class="fa fa-fw fa-unlock"></i>{$msg_unlockaccount}
+                        <i class="fa fa-fw fa-unlock mr-3"></i>
                         <i class="fa fa-fw fa-info-circle text-body-tertiary" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=unlock page=unlockaccount title=$msg_unlockaccount dn=$entry.dn returnto=$page}
+                        {include 'comment.tpl' method=unlock page=unlockaccount title=$msg_unlockaccount dn=$entry.dn returnto=$page required=$use_unlockcomment_required}
                     </div>
                 {else}
                     <a href="index.php?page=unlockaccount&dn={$entry.dn|escape:'url'}&returnto=searchlocked"
@@ -33,11 +33,11 @@
             {if $display_enable_button}
                 {if $use_enablecomment}
                     <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#commentModalenable{$entry.dn|sha256}">
-                        <i class="fa fa-fw fa-user-check"></i>{$msg_enableaccount}
+                        <i class="fa fa-fw fa-user-check mr-3"></i>
                         <i class="fa fa-fw fa-info-circle text-body-tertiary" title="{$msg_comment_needed}"></i>
                     </button>
                     <div>
-                        {include 'comment.tpl' method=enable page=enableaccount title=$msg_enableaccount dn=$entry.dn returnto=$page}
+                        {include 'comment.tpl' method=enable page=enableaccount title=$msg_enableaccount dn=$entry.dn returnto=$page required=$use_enablecomment_required}
                     </div>
                 {else}
                     <a href="index.php?page=enableaccount&dn={$entry.dn|escape:'url'}&returnto=searchdisabled"
@@ -45,8 +45,6 @@
                         <i class="fa fa-fw fa-user-check"></i>
                     </a>
                 {/if}
-
-
             {/if}
         </th>
         {foreach $listing_columns as $column}
@@ -81,18 +79,6 @@
                     title="{$msg_displayentry}">
                     <i class="fa fa-fw fa-id-card"></i>
                 </a>
-                {if $display_unlock_button}
-                <a href="index.php?page=unlockaccount&dn={$event.dn|escape:'url'}&returnto=searchlocked"
-                    class="btn btn-success btn-sm" role="button" title="{$msg_unlockaccount}">
-                    <i class="fa fa-fw fa-unlock"></i>
-                </a>
-                {/if}
-                {if $display_enable_button}
-                <a href="index.php?page=enableaccount&dn={$event.dn|escape:'url'}&returnto=searchdisabled"
-                    class="btn btn-success btn-sm" role="button" title="{$msg_enableaccount}">
-                    <i class="fa fa-fw fa-person-circle-check"></i>
-                </a>
-                {/if}
             </th>
             {foreach $listing_columns as $column}
             <td>


### PR DESCRIPTION
The "required" parameter was not correctly set:
```
{if $use_lockcomment_required || $use_unlockcomment_required}required{/if}
```

This means that if only one of the two options is true, the required field is set.

The required field should be set only if the matching option is true.

@abpai94 feel free to contact me if this is not clear for you.