### PR TITLE
display error logs even when $debug=false (#275)

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -153,7 +153,8 @@ else
     $smarty->error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING;
 }
 
-error_reporting(0);
+# By default, only display error logs and not the other levels
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING);
 if ($debug) {
     error_reporting(E_ALL);
     # Set debug for LDAP


### PR DESCRIPTION
Fixes #275 